### PR TITLE
add puma to test group in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,10 @@ group :development, :test do
   gem 'poltergeist'
 end
 
+group :test do
+  gem "puma"
+end
+
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'


### PR DESCRIPTION
Student received following error when running rspec:
```I received this Failure/Error: raise LoadError, 'Capybara is unable to load `puma` for its server, please add `puma` to your project or specify a different server via something like `Capybara.server = :webrick`.'```

I cloned the lab and was able to replicate the error locally:
`  Failure/Error: raise LoadError, 'Capybara is unable to load `puma` for its server, please add `puma` to your project or specify a different server via something like `Capybara.server = :webrick`.'
     
     LoadError:
       Capybara is unable to load `puma` for its server, please add `puma` to your project or specify a different server via something like `Capybara.server = :webrick`.`
sd

Adding puma to my gemfile resolved the error.
learn-co-curriculum has the puma gem in the gemfile